### PR TITLE
Fix stray comment in digest HTML

### DIFF
--- a/backend/app/digest/daily_digest.py
+++ b/backend/app/digest/daily_digest.py
@@ -85,9 +85,9 @@ def generate_email_summary_section(emails: List[models.Email], section_title: st
             <strong>Date:</strong> {date_str}<br>
             <strong>Subject:</strong> {email.subject}</p>
             <p><strong>Summary:</strong> {email.summary or 'No summary available'}</p>
-            <p><strong>Category:</strong> {email.category or 'Uncategorized'} | 
-            <strong>Priority:</strong> {email.priority or 'Normal'} | 
-            <strong>Importance:</strong> {email.importance or 'Normal'} |   # NEW
+            <p><strong>Category:</strong> {email.category or 'Uncategorized'} |
+            <strong>Priority:</strong> {email.priority or 'Normal'} |
+            <strong>Importance:</strong> {email.importance or 'Normal'} |
             <strong>Sentiment:</strong> {email.sentiment or 'Neutral'}</p>
         </div>
         """


### PR DESCRIPTION
## Summary
- remove a leftover `# NEW` comment from the daily digest HTML template

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v 'backend/start_worker.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683fc86d795c832da64892235654c260