### PR TITLE
Improve Google OAuth login UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ docker compose up -d --build
 
 ### Authentication
 
-1. Start Google OAuth flow: `GET /auth/google`
-2. Complete authorization and get callback token
-3. Check authentication status: `GET /auth/status`
+1. Open `/auth/login` in your browser.
+2. Click each inbox to authorize access via Google's consent screen.
+3. After Google redirects back, tokens are stored automatically.
+4. Check authentication status with `GET /auth/status`.
 
 ### Usage
 

--- a/backend/app/auth/oauth.py
+++ b/backend/app/auth/oauth.py
@@ -156,18 +156,19 @@ def setup_oauth_flow(redirect_uri: str = "http://localhost:8000/auth/callback"):
     
     return flow
 
-def get_authorization_url() -> str:
-    """Get the authorization URL for OAuth flow."""
+def get_authorization_url(email: str) -> str:
+    """Get the authorization URL for OAuth flow for a specific inbox."""
     flow = setup_oauth_flow()
     auth_url, _ = flow.authorization_url(
         access_type='offline',
         include_granted_scopes='true',
-        prompt='consent'
+        prompt='consent',
+        state=email
     )
     return auth_url
 
-def exchange_code_for_token(code: str, token_path: str = "token.json") -> dict:
-    """Exchange authorization code for access token."""
+def exchange_code_for_token(code: str, email: str, token_path: str = "token.json") -> dict:
+    """Exchange authorization code for access token and store it."""
     flow = setup_oauth_flow()
     flow.fetch_token(code=code)
     
@@ -176,6 +177,8 @@ def exchange_code_for_token(code: str, token_path: str = "token.json") -> dict:
     with open(token_path, 'w') as token_file:
         token_file.write(creds.to_json())
     
+    store_oauth_token(email, creds)
+
     return {
         "access_token": creds.token,
         "refresh_token": creds.refresh_token,


### PR DESCRIPTION
## Summary
- enable user selection of inbox for auth via `/auth/login`
- redirect to Google's consent screen and save tokens for each inbox
- document the new authentication flow

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v 'start_worker.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc942db2c832da90c5e511fd20d5b