### PR TITLE
Make LLM requests deterministic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ DOCUMENTS_FOLDER_ID=1oas1TEtW26ZNvW2jekk6Y8R2Hb85IUmn
 
 # LLM Model specification
 LLM_MODEL=mistral-7b-instruct-v0.3
+LLM_TEMPERATURE=0.2
+LLM_TOP_K=20
+LLM_TOP_P=0.7
 
 # Daily digest settings
 DIGEST_RECIPIENT=tony@ivc-valves.com

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ End‑to‑end internal Retrieval‑Augmented‑Generation system for IVC email 
 - **Gmail Integration**: Process emails from 7 specific inboxes in sequence
 - **Google Drive Integration**: Index documents with OCR processing
 - **Daily Digest**: Automated email summaries sent to tony@ivc-valves.com
-- **LLM Processing**: Mistral-7B-Instruct-v0.3 for summarization and categorization
+- **LLM Processing**: Mistral-7B-Instruct-v0.3 (configurable via `.env`) with conservative sampling to reduce hallucinations
 - **Background Queue**: Redis-based task processing
 - **RAGFlow Integration**: Vector database with search capabilities
 
@@ -38,6 +38,7 @@ docker compose up -d --build
    - Google OAuth credentials (already set from requirements)
    - Gmail inbox sequence (already configured)
    - Google Drive folder IDs (already set)
+   - LLM settings (model and sampling parameters) using `LLM_MODEL`, `LLM_TEMPERATURE`, `LLM_TOP_K`, and `LLM_TOP_P`
 
 ### Authentication
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -34,6 +34,9 @@ class Settings(BaseSettings):
     
     # LLM Model specification from requirements
     llm_model: str = Field(default="mistral-7b-instruct-v0.3", env="LLM_MODEL")
+    llm_temperature: float = Field(default=0.2, env="LLM_TEMPERATURE")
+    llm_top_k: int = Field(default=20, env="LLM_TOP_K")
+    llm_top_p: float = Field(default=0.7, env="LLM_TOP_P")
     
     # Daily digest settings from requirements
     digest_recipient: str = Field(default="tony@ivc-valves.com", env="DIGEST_RECIPIENT")

--- a/backend/app/llm/summarizer.py
+++ b/backend/app/llm/summarizer.py
@@ -8,11 +8,18 @@ def summarize_email(email_text: str, email_id: str = "") -> dict:
     """Summarize email content using the specified prompt template."""
     prompt = EMAIL_PROMPT_TEMPLATE.format(email_text=email_text, email_id=email_id)
     
-    resp = requests.post(f"{settings.ollama_host}/api/generate", json={
-        "model": "mistral",
-        "prompt": prompt,
-        "stream": False
-    }, timeout=120)
+    resp = requests.post(
+        f"{settings.ollama_host}/api/generate",
+        json={
+            "model": settings.llm_model,
+            "prompt": prompt,
+            "temperature": settings.llm_temperature,
+            "top_k": settings.llm_top_k,
+            "top_p": settings.llm_top_p,
+            "stream": False,
+        },
+        timeout=120,
+    )
     resp.raise_for_status()
     
     raw = resp.json()["response"]
@@ -30,11 +37,18 @@ def summarize_attachment(document_text: str, email_id: str = "") -> dict:
     """Summarize email attachment content using the specified prompt template."""
     prompt = ATTACHMENT_PROMPT_TEMPLATE.format(document_text=document_text, email_id=email_id)
     
-    resp = requests.post(f"{settings.ollama_host}/api/generate", json={
-        "model": "mistral",
-        "prompt": prompt,
-        "stream": False
-    }, timeout=120)
+    resp = requests.post(
+        f"{settings.ollama_host}/api/generate",
+        json={
+            "model": settings.llm_model,
+            "prompt": prompt,
+            "temperature": settings.llm_temperature,
+            "top_k": settings.llm_top_k,
+            "top_p": settings.llm_top_p,
+            "stream": False,
+        },
+        timeout=120,
+    )
     resp.raise_for_status()
     
     raw = resp.json()["response"]
@@ -50,11 +64,18 @@ def summarize_document(document_text: str, department_name: str = "") -> dict:
     """Summarize document content using the specified prompt template."""
     prompt = DOCUMENT_PROMPT_TEMPLATE.format(document_text=document_text, department_name=department_name)
     
-    resp = requests.post(f"{settings.ollama_host}/api/generate", json={
-        "model": "mistral",
-        "prompt": prompt,
-        "stream": False
-    }, timeout=120)
+    resp = requests.post(
+        f"{settings.ollama_host}/api/generate",
+        json={
+            "model": settings.llm_model,
+            "prompt": prompt,
+            "temperature": settings.llm_temperature,
+            "top_k": settings.llm_top_k,
+            "top_p": settings.llm_top_p,
+            "stream": False,
+        },
+        timeout=120,
+    )
     resp.raise_for_status()
     
     raw = resp.json()["response"]
@@ -72,11 +93,18 @@ def clean_ocr_text(ocr_text: str) -> str:
     
     prompt = OCR_CLEANING_PROMPT_TEMPLATE.format(ocr_text=ocr_text)
     
-    resp = requests.post(f"{settings.ollama_host}/api/generate", json={
-        "model": "mistral",
-        "prompt": prompt,
-        "stream": False
-    }, timeout=120)
+    resp = requests.post(
+        f"{settings.ollama_host}/api/generate",
+        json={
+            "model": settings.llm_model,
+            "prompt": prompt,
+            "temperature": settings.llm_temperature,
+            "top_k": settings.llm_top_k,
+            "top_p": settings.llm_top_p,
+            "stream": False,
+        },
+        timeout=120,
+    )
     resp.raise_for_status()
     
     return resp.json()["response"].strip()

--- a/backend/app/llm/summary_prompts.py
+++ b/backend/app/llm/summary_prompts.py
@@ -26,6 +26,7 @@ EMAIL_PROMPT_TEMPLATE = """
 You are an intelligent email assistant for Indian Valve Company (IVC).
 
 Task: Analyze and structure company emails from the {email_id} inbox for internal categorization, summarization, and storage for RAG systems.
+If you are unsure about any detail, respond with "I don't know." Only use information present in the email.
 
 Available Categories: Sales/Leads, Customer Support, Internal Communication, HR/Recruitment, Finance/Invoices, Legal/Compliance, IT/Technical Support, Marketing/PR, Operations/Logistics
 
@@ -52,6 +53,7 @@ ATTACHMENT_PROMPT_TEMPLATE = """
 You are an intelligent document assistant for Indian Valve Company (IVC).
 
 Task: Analyze and structure email attachments from the {email_id} inbox for RAG systems.
+If you are unsure about any detail, respond with "I don't know." Only use information present in the document.
 
 Available Categories: Sales Enquiry, Quotation, Drawing, Purchase Order, Invoice, Challan, Report, Test Certificate, Specifications, TPI, Contract, Accounts, Legal Document, Receipt, Plan, Presentation, Correspondence, Meeting Minutes, Customer Support, Internal Communication, HR/Recruitment, Legal/Compliance, IT/Technical Support, Marketing/PR, Operations/Logistics
 
@@ -78,6 +80,7 @@ DOCUMENT_PROMPT_TEMPLATE = """
 You are an intelligent document assistant for Indian Valve Company (IVC).
 
 Task: Analyze and structure internal/external business documents from the {department_name} department for RAG systems.
+If you are unsure about any detail, respond with "I don't know." Only use information present in the document.
 
 Available Categories: Sales Enquiry, Quotation, Drawing, Purchase Order, Invoice, Challan, Report, Test Certificate, Specifications, TPI, Contract, Accounts, Legal Document, Receipt, Plan, Presentation, Correspondence, Meeting Minutes, Customer Support, Internal Communication, HR/Recruitment, Legal/Compliance, IT/Technical Support, Marketing/PR, Operations/Logistics
 


### PR DESCRIPTION
## Summary
- configure LLM sampling via `.env` variables
- clarify prompts to answer "I don't know" when unsure
- wire up settings in summarizer
- document new environment variables in README

## Testing
- `python -m pip install -r backend/requirements.txt` *(fails: subprocess-exited-with-error)*

------
https://chatgpt.com/codex/tasks/task_e_683fecdbc480832db8f7f7dcd6e6006a