### PR TITLE
Adjust env for localhost and auto DB init

### DIFF
--- a/.env
+++ b/.env
@@ -12,6 +12,9 @@ DOCUMENTS_FOLDER_ID=1oas1TEtW26ZNvW2jekk6Y8R2Hb85IUmn
 
 # LLM Model specification
 LLM_MODEL=mistral-7b-instruct-v0.3
+LLM_TEMPERATURE=0.2
+LLM_TOP_K=20
+LLM_TOP_P=0.7
 
 # Daily digest settings
 DIGEST_RECIPIENT=tony@ivc-valves.com

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ DOCUMENTS_FOLDER_ID=1oas1TEtW26ZNvW2jekk6Y8R2Hb85IUmn
 
 # LLM Model specification
 LLM_MODEL=mistral-7b-instruct-v0.3
+LLM_TEMPERATURE=0.2
+LLM_TOP_K=20
+LLM_TOP_P=0.7
 
 # Daily digest settings
 DIGEST_RECIPIENT=tony@ivc-valves.com
@@ -28,19 +31,19 @@ SMTP_FROM_EMAIL=rag-system@ivc-valves.com
 POSTGRES_USER=raguser
 POSTGRES_PASSWORD=ragpass
 POSTGRES_DB=ragdb
-POSTGRES_HOST=postgres
+POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
 
 # ---------------- RAGFlow ---------------------
-RAGFLOW_HOST=http://ragflow:3000
+RAGFLOW_HOST=http://localhost:3000
 RAGFLOW_API_KEY=
 
 # ---------------- Redis -----------------------
-REDIS_HOST=redis
+REDIS_HOST=localhost
 REDIS_PORT=6379
 
 # ---------------- Ollama ----------------------
-OLLAMA_HOST=http://ollama:11434
+OLLAMA_HOST=http://localhost:11434
 
 # ---------------- Other -----------------------
 OPENAI_API_KEY= # optional for fallback

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ End‑to‑end internal Retrieval‑Augmented‑Generation system for IVC email 
 - **Gmail Integration**: Process emails from 7 specific inboxes in sequence
 - **Google Drive Integration**: Index documents with OCR processing
 - **Daily Digest**: Automated email summaries sent to tony@ivc-valves.com
-- **LLM Processing**: Mistral-7B-Instruct-v0.3 for summarization and categorization
+- **LLM Processing**: Mistral-7B-Instruct-v0.3 (configurable via `.env`) with conservative sampling to reduce hallucinations
 - **Background Queue**: Redis-based task processing
 - **RAGFlow Integration**: Vector database with search capabilities
 
@@ -34,10 +34,11 @@ docker compose up -d --build
 
 ### Configuration
 
-1. Copy `.env.example` to `.env` and configure:
+1. Edit the provided `.env` file if you need to change defaults:
    - Google OAuth credentials (already set from requirements)
    - Gmail inbox sequence (already configured)
    - Google Drive folder IDs (already set)
+   - LLM settings (model and sampling parameters) using `LLM_MODEL`, `LLM_TEMPERATURE`, `LLM_TOP_K`, and `LLM_TOP_P`
 
 ### Authentication
 

--- a/backend/.env
+++ b/backend/.env
@@ -12,6 +12,9 @@ DOCUMENTS_FOLDER_ID=1oas1TEtW26ZNvW2jekk6Y8R2Hb85IUmn
 
 # LLM Model specification
 LLM_MODEL=mistral-7b-instruct-v0.3
+LLM_TEMPERATURE=0.2
+LLM_TOP_K=20
+LLM_TOP_P=0.7
 
 # Daily digest settings
 DIGEST_RECIPIENT=tony@ivc-valves.com

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -34,6 +34,9 @@ class Settings(BaseSettings):
     
     # LLM Model specification from requirements
     llm_model: str = Field(default="mistral-7b-instruct-v0.3", env="LLM_MODEL")
+    llm_temperature: float = Field(default=0.2, env="LLM_TEMPERATURE")
+    llm_top_k: int = Field(default=20, env="LLM_TOP_K")
+    llm_top_p: float = Field(default=0.7, env="LLM_TOP_P")
     
     # Daily digest settings from requirements
     digest_recipient: str = Field(default="tony@ivc-valves.com", env="DIGEST_RECIPIENT")

--- a/backend/app/llm/summarizer.py
+++ b/backend/app/llm/summarizer.py
@@ -8,11 +8,18 @@ def summarize_email(email_text: str, email_id: str = "") -> dict:
     """Summarize email content using the specified prompt template."""
     prompt = EMAIL_PROMPT_TEMPLATE.format(email_text=email_text, email_id=email_id)
     
-    resp = requests.post(f"{settings.ollama_host}/api/generate", json={
-        "model": "mistral",
-        "prompt": prompt,
-        "stream": False
-    }, timeout=120)
+    resp = requests.post(
+        f"{settings.ollama_host}/api/generate",
+        json={
+            "model": settings.llm_model,
+            "prompt": prompt,
+            "temperature": settings.llm_temperature,
+            "top_k": settings.llm_top_k,
+            "top_p": settings.llm_top_p,
+            "stream": False,
+        },
+        timeout=120,
+    )
     resp.raise_for_status()
     
     raw = resp.json()["response"]
@@ -30,11 +37,18 @@ def summarize_attachment(document_text: str, email_id: str = "") -> dict:
     """Summarize email attachment content using the specified prompt template."""
     prompt = ATTACHMENT_PROMPT_TEMPLATE.format(document_text=document_text, email_id=email_id)
     
-    resp = requests.post(f"{settings.ollama_host}/api/generate", json={
-        "model": "mistral",
-        "prompt": prompt,
-        "stream": False
-    }, timeout=120)
+    resp = requests.post(
+        f"{settings.ollama_host}/api/generate",
+        json={
+            "model": settings.llm_model,
+            "prompt": prompt,
+            "temperature": settings.llm_temperature,
+            "top_k": settings.llm_top_k,
+            "top_p": settings.llm_top_p,
+            "stream": False,
+        },
+        timeout=120,
+    )
     resp.raise_for_status()
     
     raw = resp.json()["response"]
@@ -50,11 +64,18 @@ def summarize_document(document_text: str, department_name: str = "") -> dict:
     """Summarize document content using the specified prompt template."""
     prompt = DOCUMENT_PROMPT_TEMPLATE.format(document_text=document_text, department_name=department_name)
     
-    resp = requests.post(f"{settings.ollama_host}/api/generate", json={
-        "model": "mistral",
-        "prompt": prompt,
-        "stream": False
-    }, timeout=120)
+    resp = requests.post(
+        f"{settings.ollama_host}/api/generate",
+        json={
+            "model": settings.llm_model,
+            "prompt": prompt,
+            "temperature": settings.llm_temperature,
+            "top_k": settings.llm_top_k,
+            "top_p": settings.llm_top_p,
+            "stream": False,
+        },
+        timeout=120,
+    )
     resp.raise_for_status()
     
     raw = resp.json()["response"]
@@ -72,11 +93,18 @@ def clean_ocr_text(ocr_text: str) -> str:
     
     prompt = OCR_CLEANING_PROMPT_TEMPLATE.format(ocr_text=ocr_text)
     
-    resp = requests.post(f"{settings.ollama_host}/api/generate", json={
-        "model": "mistral",
-        "prompt": prompt,
-        "stream": False
-    }, timeout=120)
+    resp = requests.post(
+        f"{settings.ollama_host}/api/generate",
+        json={
+            "model": settings.llm_model,
+            "prompt": prompt,
+            "temperature": settings.llm_temperature,
+            "top_k": settings.llm_top_k,
+            "top_p": settings.llm_top_p,
+            "stream": False,
+        },
+        timeout=120,
+    )
     resp.raise_for_status()
     
     return resp.json()["response"].strip()

--- a/backend/app/llm/summary_prompts.py
+++ b/backend/app/llm/summary_prompts.py
@@ -26,6 +26,7 @@ EMAIL_PROMPT_TEMPLATE = """
 You are an intelligent email assistant for Indian Valve Company (IVC).
 
 Task: Analyze and structure company emails from the {email_id} inbox for internal categorization, summarization, and storage for RAG systems.
+If you are unsure about any detail, respond with "I don't know." Only use information present in the email.
 
 Available Categories: Sales/Leads, Customer Support, Internal Communication, HR/Recruitment, Finance/Invoices, Legal/Compliance, IT/Technical Support, Marketing/PR, Operations/Logistics
 
@@ -52,6 +53,7 @@ ATTACHMENT_PROMPT_TEMPLATE = """
 You are an intelligent document assistant for Indian Valve Company (IVC).
 
 Task: Analyze and structure email attachments from the {email_id} inbox for RAG systems.
+If you are unsure about any detail, respond with "I don't know." Only use information present in the document.
 
 Available Categories: Sales Enquiry, Quotation, Drawing, Purchase Order, Invoice, Challan, Report, Test Certificate, Specifications, TPI, Contract, Accounts, Legal Document, Receipt, Plan, Presentation, Correspondence, Meeting Minutes, Customer Support, Internal Communication, HR/Recruitment, Legal/Compliance, IT/Technical Support, Marketing/PR, Operations/Logistics
 
@@ -78,6 +80,7 @@ DOCUMENT_PROMPT_TEMPLATE = """
 You are an intelligent document assistant for Indian Valve Company (IVC).
 
 Task: Analyze and structure internal/external business documents from the {department_name} department for RAG systems.
+If you are unsure about any detail, respond with "I don't know." Only use information present in the document.
 
 Available Categories: Sales Enquiry, Quotation, Drawing, Purchase Order, Invoice, Challan, Report, Test Certificate, Specifications, TPI, Contract, Accounts, Legal Document, Receipt, Plan, Presentation, Correspondence, Meeting Minutes, Customer Support, Internal Communication, HR/Recruitment, Legal/Compliance, IT/Technical Support, Marketing/PR, Operations/Logistics
 

--- a/backend/scripts/run_server.sh
+++ b/backend/scripts/run_server.sh
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 set -e
+
+# Ensure database tables exist before starting
+bash $(dirname "$0")/init_db.sh
+
 uvicorn app.main:app --host 0.0.0.0 --port 8000

--- a/backend/scripts/run_worker.sh
+++ b/backend/scripts/run_worker.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
+# Ensure database tables exist before starting
+bash $(dirname "$0")/init_db.sh
+
 # Start RQ worker for background tasks
 echo "Starting RQ worker for email, document, and digest processing..."
 
-python ../start_worker.py
+python -m app.queue.tasks

--- a/backend/start_worker.py
+++ b/backend/start_worker.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-echo "Starting RQ worker for email, document, and digest processing..."
-
-# Run the worker
-python -m app.queue.tasks


### PR DESCRIPTION
## Summary
- configure `.env` for localhost services
- keep example env in sync
- ensure server and worker init the database on start
- remove unused `start_worker.py`

## Testing
- `python -m pip install -r backend/requirements.txt` *(fails: Getting requirements to build wheel did not run successfully)*

------
https://chatgpt.com/codex/tasks/task_e_683fecdbc480832db8f7f7dcd6e6006a