### PR TITLE
Align prompts and email model with plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ docker compose up -d --build
 |-----------|------|-------------------------------|
 | backend   | 8000 | FastAPI + API endpoints       |
 | worker    | -    | Background task processing    |
+| frontend  | 8080 | Simple search UI              |
 | RAGFlow   | 3000 | Vector DB & search UI         |
 | Ollama    | 11434| Local Mistral 7B LLM          |
 | PostgreSQL| 5432 | Structured data storage       |
@@ -119,6 +120,7 @@ Search queries are executed across **all** knowledge bases.
 ### Access URLs
 
 - API Documentation: http://localhost:8000/docs
+- Frontend UI: http://localhost:8080
 - RAGFlow UI: http://localhost:3000
 - Health Check: http://localhost:8000/health
 

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -19,7 +19,8 @@ class Email(Base):
     subject = Column(Text)
     body = Column(Text)
     sender = Column(String(255))  # email id and/or name
-    recipients = Column(ARRAY(String))  # email id and/or name as TEXT[]
+    to = Column(ARRAY(String))  # list of To email ids
+    cc = Column(ARRAY(String))  # list of CC email ids
     date = Column(TIMESTAMP(timezone=True))  # TIMESTAMP WITH TIME ZONE
     labels = Column(ARRAY(String(50)))  # inbox/sent/draft etc. as VARCHAR(50)[]
     attachments = Column(JSON)  # e.g., { attachment_id:123, filename: "file.pdf", gdrive_id: "xyz", size:1540}

--- a/backend/app/digest/daily_digest.py
+++ b/backend/app/digest/daily_digest.py
@@ -72,8 +72,9 @@ def generate_email_summary_section(emails: List[models.Email], section_title: st
         
         # Get inbox from recipients (simplified)
         inbox = "Unknown"
-        if email.recipients:
-            for recipient in email.recipients:
+        recipients = (email.to or []) + (email.cc or [])
+        if recipients:
+            for recipient in recipients:
                 if '@ivc-valves.com' in recipient:
                     inbox = recipient
                     break
@@ -108,8 +109,9 @@ def generate_daily_digest_html(emails: List[models.Email]) -> str:
     # Count by inbox
     inbox_counts = {}
     for email in emails:
-        if email.recipients:
-            for recipient in email.recipients:
+        recipients = (email.to or []) + (email.cc or [])
+        if recipients:
+            for recipient in recipients:
                 if '@ivc-valves.com' in recipient or '@gmail.com' in recipient:
                     inbox_counts[recipient] = inbox_counts.get(recipient, 0) + 1
     

--- a/backend/app/llm/summarizer.py
+++ b/backend/app/llm/summarizer.py
@@ -1,12 +1,32 @@
 import requests, json
 from app.config import get_settings
-from app.llm.summary_prompts import EMAIL_PROMPT_TEMPLATE, ATTACHMENT_PROMPT_TEMPLATE, DOCUMENT_PROMPT_TEMPLATE
+from app.llm.summary_prompts import (
+    EMAIL_PROMPT_TEMPLATE,
+    ATTACHMENT_PROMPT_TEMPLATE,
+    DOCUMENT_PROMPT_TEMPLATE,
+)
 
 settings = get_settings()
 
-def summarize_email(email_text: str, email_id: str = "") -> dict:
+def summarize_email(
+    from_email: str,
+    to_list: list,
+    cc_list: list,
+    subject: str,
+    date_str: str,
+    body: str,
+    email_id: str = "",
+) -> dict:
     """Summarize email content using the specified prompt template."""
-    prompt = EMAIL_PROMPT_TEMPLATE.format(email_text=email_text, email_id=email_id)
+    prompt = EMAIL_PROMPT_TEMPLATE.format(
+        from_email=from_email,
+        to_list=", ".join(to_list) if to_list else "Not specified",
+        cc_list=", ".join(cc_list) if cc_list else "Not specified",
+        subject=subject,
+        email_date=date_str or "Not specified",
+        body=body,
+        email_id=email_id,
+    )
     
     resp = requests.post(
         f"{settings.ollama_host}/api/generate",

--- a/backend/app/llm/summary_prompts.py
+++ b/backend/app/llm/summary_prompts.py
@@ -1,103 +1,187 @@
 # OCR Error Correction Prompt
 OCR_CLEANING_PROMPT_TEMPLATE = """
-You are an advanced text correction model specializing in OCR errors for Indian Valve Company (IVC).
-
-Context: Documents may include technical terms, part codes, invoices, purchase orders, test certificates, or legal/commercial communication.
-
-Task: Clean and correct the following OCR text, preserving meaning and formatting.
-
-Techniques to apply:
-- Fix common OCR misrecognitions (e.g., 'O' vs '0', 'l' vs '1', 'rn' vs 'm')
-- Restore broken words and line splits
-- Remove/correct repeated characters or formatting noise
-- Preserve important layout/structure (e.g., tabular data, headings)
-- Retain numerical values, dates, codes, units unless clearly corrupted
-
-Constraint: Do not invent content; only correct likely OCR errors based on context.
-
-Raw OCR text:
+You are an advanced text correction model specializing in fixing OCR (Optical Character Recognition) errors in scanned documents. The OCR output may contain character substitutions, missing or extra symbols, line breaks, or formatting issues. You are tasked with cleaning and correcting this text while preserving the original meaning and formatting as accurately as possible.
+The document belongs to Indian Valve Company (IVC), a valve manufacturing firm, and may include technical terms, part codes, invoices, purchase orders, test certificates, or legal/commercial communication. Use domain context to resolve ambiguities and maintain proper casing, punctuation, and spacing.
+Apply the following correction techniques:
+- Fix common OCR misrecognitions (e.g., 'O' vs '0', 'l' vs '1', 'rn' vs 'm', etc.)
+- Restore broken words and line splits using sentence-level context.
+- Remove or correct repeated characters or formatting noise (e.g., '**==', '~~', '|_|', etc.)
+- Preserve important layout or structure when needed (e.g., tabular data, headings).
+- Retain all numerical values, dates, codes, and units as-is unless clearly corrupted.
+Input OCR Text:
 {ocr_text}
-
-Corrected text:
+Your Output:
+Return a clean, corrected version of the text, suitable for further structured processing or storage in a database. Do not invent content; only correct what is likely to be OCR error based on context.
 """
 
 # Email Summary Prompt
 EMAIL_PROMPT_TEMPLATE = """
-You are an intelligent email assistant for Indian Valve Company (IVC).
+You are an intelligent email assistant for Indian Valve (IVC), a valve manufacturing company serving water infrastructure government projects and contractors. Your role is to analyze and structure company emails for internal categorization, summarization and storage in a local database for retrieval-augmented generation (RAG) systems. Only use information present in the email. If something is missing or unclear, answer "Not specified". Do not guess or add information.  
+Given the email below (including subject, email header and body), perform the following tasks:
+Summary (3–5 sentences):
+Summarize the email in a formal business tone, avoid markdown. Cover:
+– Main purpose or request
+– Key deadlines or dates (if any)
+– Required actions or decisions
+– Any critical numbers, documents, or data points
+– Any other relevant context
+Urgency: Classify as one of: Urgent / Normal / Low Priority
+Sentiment: Classify as one of: Positive / Neutral / Negative
+Importance: Choose one: Very Important / Normal / Low Importance
+Keywords: Identify 3–5 important keywords or key phrases from the email
+Category: Assign the most relevant category from the list below based on content and intent. If no category fits well, suggest a new one.
+Available Categories:
+-Delay/Follow-up/Reminder/Pending/Shortage
+-Maintenance/Repair/Problem/Defect/Issue/Support Request
+-Drawing/GAD
+-Inspection/TPI
+-Quality Assurance/QAP
+-Customer Sales Inquiry/Request for Quotation
+-Customer Quotation
+-Quotation from Vendor/Supplier
+-Project Documentation/Approval Process
+-Job Application
+-Purchase Order
+-Advance Bank Guarantee/ABG
+-Performance Bank Guarantee/PBG
+-Financial Compliance/Document Submission
+-Documentation/Compliance
+-Vendor Invoice/Bill/Outgoing Payment/Due
+-Customer Invoice/Incoming Payment/LC/Letter of Credit/RTGS
+-Unsolicited marketing/Newsletter/Promotion
+-Operations/Logistics
 
-Task: Analyze and structure company emails from the {email_id} inbox for internal categorization, summarization, and storage for RAG systems.
-If you are unsure about any detail, respond with "I don't know." Only use information present in the email.
+Email to process:
+From: {from_email}
+To: {to_list}
+cc: {cc_list}
+Date: {email_date}
+Subject: {subject}
+Email body: {body}
 
-Available Categories: Sales/Leads, Customer Support, Internal Communication, HR/Recruitment, Finance/Invoices, Legal/Compliance, IT/Technical Support, Marketing/PR, Operations/Logistics
+Your response format:
 
-Email content:
-{email_text}
-
-Provide your analysis in the following format:
-
-Summary: [3-5 sentences in formal business tone, no markdown. Cover main purpose/request, key deadlines/dates, required actions/decisions, critical numbers/documents/data, other relevant context]
-
-Urgency: [Urgent / Normal / Low Priority]
-
-Sentiment: [Positive / Neutral / Negative]
-
-Importance: [Very Important / Normal / Low Importance]
-
-Keywords: [3-5 important keywords/phrases, comma-separated]
-
-Category: [Assign from available categories or suggest a new one]
+Summary: [Concise summary here]
+Urgency: [Urgent/Normal/Low Priority]
+Sentiment: [Positive/Neutral/Negative]
+Importance: [Very Important/Normal/Low Importance]
+Keywords: [keyword1, keyword2, keyword3, ...]
+Category: [Most relevant category or new suggestion]
 """
 
-# Email Attachment Summary Prompt  
+# Email Attachment Summary Prompt
 ATTACHMENT_PROMPT_TEMPLATE = """
-You are an intelligent document assistant for Indian Valve Company (IVC).
+You are an intelligent document assistant for Indian Valve Company (IVC), a valve manufacturing firm serving water infrastructure projects for government bodies and contractors. Your role is to analyze and structure email attachments for internal categorization, summarization, and storage in a local database for retrieval-augmented generation (RAG) systems. . If something is missing or unclear, answer "Not specified". Do not guess or add information.  
 
-Task: Analyze and structure email attachments from the {email_id} inbox for RAG systems.
-If you are unsure about any detail, respond with "I don't know." Only use information present in the document.
+The following is an attachment received via email from the {email_id} inbox. Analyze its content carefully and perform the tasks below:
 
-Available Categories: Sales Enquiry, Quotation, Drawing, Purchase Order, Invoice, Challan, Report, Test Certificate, Specifications, TPI, Contract, Accounts, Legal Document, Receipt, Plan, Presentation, Correspondence, Meeting Minutes, Customer Support, Internal Communication, HR/Recruitment, Legal/Compliance, IT/Technical Support, Marketing/PR, Operations/Logistics
+1. Summary (3–5 sentences):
+Write a formal summary covering:
+– The main purpose or intent of the document
+– Any critical numbers, values, attachments, or referenced documents
+– Deadlines, dates, or time-sensitive elements (if any)
+– Required actions, follow-ups, or decisions
+– Any other relevant technical or business context
+2. Urgency: Classify as one of: Urgent / Normal / Low Priority
+3. Sentiment: Classify as one of: Positive / Neutral / Negative
+4. Importance: Classify as one of: Very Important/Normal/Low Importance
+5  Keywords: Identify 3–5 important keywords or key phrases from the email
+6. Category: Assign the most relevant category from the list below based on content and intent. If no category fits well, suggest a new one.
+Available Categories:
+   - Sales Inquiry/Request for Quotation
+   - Quotation
+   - Drawing/GAD
+   - Purchase Order
+   - Invoice/Bill
+   - Challan
+   - Report
+   - Test Certificate
+   - Specifications
+   - Inspection/TPI
+   - Quality Assurance Plan/QAP
+   - Bang Guarantee/ABG/PBG
+   - Contract
+   - Accounts
+   - Compliance
+   - Legal Document
+   - Receipt
+   - Plan
+   - Presentation
+   - Correspondence
+   - Meeting Minutes
+   - Customer Support
+   - Internal Communication
+   - HR/Recruitment
+   - IT/Technical Support
+   - Marketing/PR
+   - Operations/Logistics
 
-Document content:
+document to process:
 {document_text}
 
-Provide your analysis in the following format:
+Your response format:
 
-Summary: [3-5 sentences formal summary covering main purpose/intent, critical numbers/values/attachments/referenced documents, deadlines/dates, required actions/follow-ups/decisions, other relevant technical/business context]
-
-Urgency: [Urgent / Normal / Low Priority]
-
-Sentiment: [Positive / Neutral / Negative]
-
-Importance: [Very Important / Normal / Low Importance]
-
-Keywords: [3-5 important keywords/phrases, comma-separated]
-
-Category: [Assign from available categories or suggest a new one]
+Summary: [Concise summary here]
+Urgency: [Urgent/Normal/Low Priority]
+Sentiment: [Positive/Neutral/Negative]
+Importance: [Very Important/Normal/Low Importance]
+Keywords: [keyword1, keyword2, keyword3, ...]
+Category: [Most relevant category or new suggestion]
 """
 
 # Document Summary Prompt
 DOCUMENT_PROMPT_TEMPLATE = """
-You are an intelligent document assistant for Indian Valve Company (IVC).
+You are an intelligent document assistant for Indian Valve Company (IVC), a valve manufacturing company serving water infrastructure government projects and contractors. Your role is to analyze and structure internal and external business documents for internal categorization, summarization and storage in a local database for retrieval-augmented generation (RAG) systems. . If something is missing or unclear, answer "Not specified". Do not guess or add information.  
 
-Task: Analyze and structure internal/external business documents from the {department_name} department for RAG systems.
-If you are unsure about any detail, respond with "I don't know." Only use information present in the document.
-
-Available Categories: Sales Enquiry, Quotation, Drawing, Purchase Order, Invoice, Challan, Report, Test Certificate, Specifications, TPI, Contract, Accounts, Legal Document, Receipt, Plan, Presentation, Correspondence, Meeting Minutes, Customer Support, Internal Communication, HR/Recruitment, Legal/Compliance, IT/Technical Support, Marketing/PR, Operations/Logistics
-
-Document content:
+Given the document below from the {department_name} department, perform these tasks:
+1. Summary (3–5 sentences):
+Summarize the document content in a formal business tone. Avoid markdown or bullet points. Include:
+– The main purpose of the document
+– Any critical numbers, data, attachments, or document references
+– Deadlines, dates, or time-sensitive information (if any)
+– Required actions, decisions, or follow-ups
+– Any other relevant business context
+2. Urgency: Classify as one of the following: Urgent / Normal / Low Priority
+3. Sentiment: Classify the overall tone as: Positive / Neutral / Negative
+4. Importance: Choose one: Very Important / Normal / Low Importance
+5. Keywords: Identify 3–5 important keywords or key phrases that best represent the document's content
+6. Category: Assign the most relevant category from the list below based on content and business intent. If none fit well, suggest a new category.
+Available Categories:
+   - Sales Inquiry/Request for Quotation
+   - Quotation
+   - Drawing/GAD
+   - Purchase Order
+   - Invoice/Bill
+   - Challan
+   - Report
+   - Test Certificate
+   - Specifications
+   - Inspection/TPI
+   - Quality Assurance Plan/QAP
+   - Bang Guarantee/ABG/PBG
+   - Contract
+   - Accounts
+   - Compliance
+   - Legal Document
+   - Receipt
+   - Plan
+   - Presentation
+   - Correspondence
+   - Meeting Minutes
+   - Customer Support
+   - Internal Communication
+   - HR/Recruitment
+   - IT/Technical Support
+   - Marketing/PR
+   - Operations/Logistics
+Document to Process:
 {document_text}
 
-Provide your analysis in the following format:
-
-Summary: [3-5 sentences in formal business tone, avoid markdown/bullet points. Include main purpose, critical numbers/data/attachments/document references, deadlines/dates, required actions/decisions/follow-ups, other relevant business context]
-
-Urgency: [Urgent / Normal / Low Priority]
-
-Sentiment: [Positive / Neutral / Negative]
-
-Importance: [Very Important / Normal / Low Importance]
-
-Keywords: [3-5 important keywords/phrases, comma-separated]
-
-Category: [Assign from available categories or suggest a new one]
+Your Response Format:
+Summary: [Concise summary here]
+Urgency: [Urgent/Normal/Low Priority]
+Sentiment: [Positive/Neutral/Negative]
+Importance: [Very Important/Normal/Low Importance]
+Keywords: [keyword1, keyword2, keyword3, ...]
+Category: [Most relevant category or suggested new category]
 """

--- a/backend/app/schemas/schemas.py
+++ b/backend/app/schemas/schemas.py
@@ -8,7 +8,8 @@ class EmailIn(BaseModel):
     subject: str
     body: str
     sender: str
-    recipients: List[str]
+    to: List[str] = Field(default_factory=list)
+    cc: List[str] = Field(default_factory=list)
     date: datetime.datetime
     labels: List[str]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,11 @@ services:
   backend:
     build: ./backend
     env_file: .env
+    environment:
+      POSTGRES_HOST: postgres
+      REDIS_HOST: redis
+      RAGFLOW_HOST: http://ragflow:3000
+      OLLAMA_HOST: http://ollama:11434
     depends_on:
       - postgres
       - redis
@@ -41,9 +46,22 @@ services:
     command: ["bash", "scripts/run_server.sh"]
     restart: unless-stopped
 
+  frontend:
+    build: ./frontend
+    ports:
+      - "8080:80"
+    depends_on:
+      - backend
+    restart: unless-stopped
+
   worker:
     build: ./backend
     env_file: .env
+    environment:
+      POSTGRES_HOST: postgres
+      REDIS_HOST: redis
+      RAGFLOW_HOST: http://ragflow:3000
+      OLLAMA_HOST: http://ollama:11434
     depends_on:
       - postgres
       - redis

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY . /usr/share/nginx/html

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>RAGFlow MVP</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <nav>
+    <button data-tab="search">Search</button>
+    <button data-tab="emails">Emails</button>
+    <button data-tab="documents">Documents</button>
+    <button data-tab="queue">Queue</button>
+  </nav>
+  <div id="content">
+    <section id="search" class="tab active">
+      <h2>Search</h2>
+      <input type="text" id="query" placeholder="Ask a question" />
+      <button id="searchBtn">Search</button>
+      <pre id="searchResult"></pre>
+    </section>
+    <section id="emails" class="tab">
+      <h2>Emails</h2>
+      <div>
+        <label>Inbox:</label>
+        <select id="emailInbox" multiple></select>
+        <label>Category:</label>
+        <input type="text" id="emailCategory" placeholder="Category" />
+        <button id="loadEmails">Load</button>
+      </div>
+      <ul id="emailList"></ul>
+    </section>
+    <section id="documents" class="tab">
+      <h2>Documents</h2>
+      <div>
+        <label>Type:</label>
+        <input type="text" id="docType" placeholder="source type" />
+        <label>Category:</label>
+        <input type="text" id="docCategory" placeholder="category" />
+        <button id="loadDocs">Load</button>
+      </div>
+      <ul id="docList"></ul>
+    </section>
+    <section id="queue" class="tab">
+      <h2>Processing Queue</h2>
+      <div>
+        <button id="prevPage">Prev</button>
+        <button id="nextPage">Next</button>
+      </div>
+      <ul id="queueList"></ul>
+    </section>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,0 +1,70 @@
+const tabs=document.querySelectorAll('nav button');
+const sections=document.querySelectorAll('.tab');
+
+tabs.forEach(btn=>btn.addEventListener('click',()=>{
+  sections.forEach(sec=>sec.classList.remove('active'));
+  document.getElementById(btn.dataset.tab).classList.add('active');
+}));
+
+async function fetchJSON(url){
+  const res=await fetch(url);
+  return res.json();
+}
+
+document.getElementById('searchBtn').addEventListener('click',async()=>{
+  const q=document.getElementById('query').value;
+  const data=await fetchJSON(`/api/search?q=${encodeURIComponent(q)}`);
+  document.getElementById('searchResult').textContent=JSON.stringify(data,null,2);
+});
+
+async function loadInboxes(){
+  const data=await fetchJSON('/api/inbox/list');
+  const select=document.getElementById('emailInbox');
+  data.inboxes.forEach(addr=>{
+    const opt=document.createElement('option');
+    opt.value=addr;opt.textContent=addr;select.appendChild(opt);
+  });
+}
+loadInboxes();
+
+document.getElementById('loadEmails').addEventListener('click',async()=>{
+  const inboxSelect=document.getElementById('emailInbox');
+  const selected=[...inboxSelect.selectedOptions].map(o=>o.value).join(',');
+  const cat=document.getElementById('emailCategory').value;
+  const data=await fetchJSON(`/api/emails?inboxes=${encodeURIComponent(selected)}&category=${encodeURIComponent(cat)}`);
+  const ul=document.getElementById('emailList');
+  ul.innerHTML='';
+  data.emails.forEach(e=>{
+    const li=document.createElement('li');
+    li.textContent=`${e.date} - ${e.subject}`;
+    ul.appendChild(li);
+  });
+});
+
+document.getElementById('loadDocs').addEventListener('click',async()=>{
+  const type=document.getElementById('docType').value;
+  const cat=document.getElementById('docCategory').value;
+  const data=await fetchJSON(`/api/documents?source_type=${encodeURIComponent(type)}&category=${encodeURIComponent(cat)}`);
+  const ul=document.getElementById('docList');
+  ul.innerHTML='';
+  data.documents.forEach(d=>{
+    const li=document.createElement('li');
+    li.textContent=`${d.doc_metadata.filename || 'doc'} - ${d.category}`;
+    ul.appendChild(li);
+  });
+});
+
+let queueOffset=0;
+async function loadQueue(){
+  const data=await fetchJSON(`/api/processing_queue/list?offset=${queueOffset}&limit=10`);
+  const ul=document.getElementById('queueList');
+  ul.innerHTML='';
+  data.items.forEach(item=>{
+    const li=document.createElement('li');
+    li.textContent=`${item.created_at} - ${item.item_type} - ${item.status}`;
+    ul.appendChild(li);
+  });
+}
+document.getElementById('nextPage').addEventListener('click',()=>{queueOffset+=10;loadQueue();});
+document.getElementById('prevPage').addEventListener('click',()=>{queueOffset=Math.max(0,queueOffset-10);loadQueue();});
+loadQueue();

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,6 @@
+body{font-family:Arial,sans-serif;margin:20px}
+nav{margin-bottom:10px}
+.tab{display:none}
+.tab.active{display:block}
+button{margin-right:5px}
+ul{list-style:none;padding:0}


### PR DESCRIPTION
## Summary
- update LLM prompt templates to final versions
- include email headers when summarising and store To/CC lists
- strip disclaimers from fetched emails
- adjust daily digest logic for new fields
- fix Docker compose environment

## Testing
- `python -m py_compile backend/app/llm/summarizer.py backend/app/llm/summary_prompts.py backend/app/ingest/gmail_fetcher.py backend/app/db/models.py backend/app/schemas/schemas.py backend/app/digest/daily_digest.py backend/app/main.py`
- `docker compose build` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840065efa54832dbfcf2a4820da16f2